### PR TITLE
Preserve schema of input dataframe

### DIFF
--- a/custom-recipes/to-excel/recipe.py
+++ b/custom-recipes/to-excel/recipe.py
@@ -54,7 +54,7 @@ with tempfile.NamedTemporaryFile() as tmp_file:
     tmp_file_path = tmp_file.name
     logger.info("Intend to write the output xls file to the following location: {}".format(tmp_file_path))
 
-    dataframes_to_xlsx(input_datasets_names, tmp_file_path, lambda name: dataiku.Dataset(name).get_dataframe())
+    dataframes_to_xlsx(input_datasets_names, tmp_file_path, lambda name: dataiku.Dataset(name).get_dataframe(infer_with_pandas=False))
 
     with open(tmp_file_path, 'rb', encoding=None) as f:
         output_folder.upload_stream(output_file_name, f)


### PR DESCRIPTION
Plugin does not fully export formatted text if the formatted text is made up of numbers.  Especially problematic if the string contains a number starting with '0'.   So, '019' exports as 19 which is not correct.

Change the get_dataframe call to so that infer_with_pandas = False

This more closely matches the native "Export xlsx" functionality in DSS.