### PR TITLE
[sc-184418] support dataset conditional formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ unit.xml
 .hypothesis/
 .pytest_cache/
 cover/
+tests/allure_report/
 
 # Translations
 *.mo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Version 1.1.5](https://github.com/dataiku/dss-plugin-multisheet-excel-export/releases/tag/v1.1.5) - Feature release - 2024-06
 - Export dataset conditional formatting colors (colors the cells, does not export rules)
+- Bug fix : can now export dataset with date types
+- Preserve DSS types in cells (string, numbers, date, bool)
 
 ## [Version 1.1.4](https://github.com/dataiku/dss-plugin-multisheet-excel-export/releases/tag/v1.1.4) - Bug release - 2024-06
 - Fix numpy issue with DSS 13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Version 1.1.5](https://github.com/dataiku/dss-plugin-multisheet-excel-export/releases/tag/v1.1.5) - Feature release - 2024-06
+- Export dataset conditional formatting colors (colors the cells, does not export rules)
+
 ## [Version 1.1.4](https://github.com/dataiku/dss-plugin-multisheet-excel-export/releases/tag/v1.1.4) - Bug release - 2024-06
 - Fix numpy issue with DSS 13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## [Version 1.1.5](https://github.com/dataiku/dss-plugin-multisheet-excel-export/releases/tag/v1.1.5) - Feature release - 2024-06
+## [Version 2.0.0](https://github.com/dataiku/dss-plugin-multisheet-excel-export/releases/tag/v1.1.5) - Major release - 2024-07
+- Important : Column type changed ! From this version, cells type in excel will reflect the DSS storage type in DSS. For example, string column containing only numbers will be exported as text column. If you want a number column in excel, you need to have a integer/float column on DSS
 - Export dataset conditional formatting colors (colors the cells, does not export rules)
 - Bug fix : can now export dataset with date types
-- Preserve DSS types in cells (string, numbers, date, bool)
 
 ## [Version 1.1.4](https://github.com/dataiku/dss-plugin-multisheet-excel-export/releases/tag/v1.1.4) - Bug release - 2024-06
 - Fix numpy issue with DSS 13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Version 2.0.0](https://github.com/dataiku/dss-plugin-multisheet-excel-export/releases/tag/v1.1.5) - Major release - 2024-07
-- Important : Column type changed ! From this version, cells type in excel will reflect the DSS storage type in DSS. For example, string column containing only numbers will be exported as text column. If you want a number column in excel, you need to have a integer/float column on DSS
+- Important : Column type changed ! From this version, cell types in excel will reflect the storage type in DSS. For example, string column containing only numbers will be exported as text column. If you want a number column in excel, you need to have a integer/float column on DSS
 - Export dataset conditional formatting colors (colors the cells, does not export rules)
 - Bug fix : can now export dataset with date types
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Version 2.0.0](https://github.com/dataiku/dss-plugin-multisheet-excel-export/releases/tag/v1.1.5) - Major release - 2024-07
+## [Version 2.0.0](https://github.com/dataiku/dss-plugin-multisheet-excel-export/releases/tag/v2.0.0) - Major release - 2024-07
 - Important : Column type changed ! From this version, cell types in excel will reflect the storage type in DSS. For example, string column containing only numbers will be exported as text column. If you want a number column in excel, you need to have a integer/float column on DSS
 - Export dataset conditional formatting colors (colors the cells, does not export rules)
 - Bug fix : can now export dataset with date types

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Plugin information
+# Multisheet excel export Plugin
 
 This plugin converts several DSS datasets to one multi-sheet excel (`.xlsx`) file containing one sheet per input dataset.
+More information in the [Documentation](https://www.dataiku.com/product/plugins/multisheet-excel-export/)
 
 # Prerequisites
 
@@ -17,3 +18,10 @@ It will create a folder in your flow containing the output `.xls` file. Each she
 
 In order to run the tests contained in `python-test\`, launch the following command from the plugin root directory: 
 `PYTHONPATH=$PYTHONPATH:/path/to/python-lib pytest`
+
+
+### Licence
+
+Copyright 2020-2022 Dataiku SAS
+
+This plugin is distributed under the Apache License version 2.0

--- a/custom-recipes/to-excel/recipe.json
+++ b/custom-recipes/to-excel/recipe.json
@@ -37,8 +37,15 @@
             "type": "STRING",
             "defaultValue": "output",
             "mandatory": true
+        },
+        {
+            "name": "export_conditional_formatting",
+            "label": "Apply conditional formatting",
+            "description": "Color cells by rules, when applicable",
+            "type": "BOOLEAN",
+            "defaultValue": false,
+            "mandatory": true
         }
-
     ],
     "resourceKeys" : []
 }

--- a/custom-recipes/to-excel/recipe.py
+++ b/custom-recipes/to-excel/recipe.py
@@ -34,16 +34,17 @@ def get_excel_worksheet(dataset: dataiku.Dataset, apply_conditional_formatting: 
                 tmp_file.write(chunk)
         tmp_file.flush() # Make sure file is written on disk
         tmp_file.seek(0) # Read back from start of file to load it in the workbook
+
+        # DEV WARNING : Excel exported file contains header row in Calibri and rest in Aptos Narrow font. But load_workbook converts everything into Calibri
         workbook = load_workbook(tmp_file)
 
-    
     if workbook is not None:
         if DEFAULT_DATAIKU_SHEET_NAME in workbook:
             return workbook[DEFAULT_DATAIKU_SHEET_NAME]
         elif len(workbook.sheetnames) == 1:
             logger.warn(f"Default DSS default sheet name has changed from {DEFAULT_DATAIKU_SHEET_NAME} to {workbook.sheetnames[0]}")
             return workbook[workbook.sheetnames[0]]
-    
+
     logger.error("Error getting Excel workbook from DSS dataset {dataset.short_name}, this dataset will not be exported")
     return None
 

--- a/custom-recipes/to-excel/recipe.py
+++ b/custom-recipes/to-excel/recipe.py
@@ -21,7 +21,7 @@ DEFAULT_DATAIKU_SHEET_NAME = "Sheet1"
 READ_CHUNK_SIZE = 1024 * 1024 # 1Mbytes
 
 def get_excel_worksheet(dataset: dataiku.Dataset, apply_conditional_formatting: bool):
-    logger.info(f"Getting Excel workbook from DSS dataset {dataset.short_name}...")
+    logger.info(f"Getting Excel workbook from DSS dataset {dataset.short_name}")
     wb = None
     with tempfile.NamedTemporaryFile(delete=True) as tmp_file:
         with dataset.raw_formatted_data(format="excel", format_params={ "applyColoring": apply_conditional_formatting }) as stream:

--- a/custom-recipes/to-excel/recipe.py
+++ b/custom-recipes/to-excel/recipe.py
@@ -54,7 +54,7 @@ with tempfile.NamedTemporaryFile() as tmp_file:
     tmp_file_path = tmp_file.name
     logger.info("Intend to write the output xls file to the following location: {}".format(tmp_file_path))
 
-    dataframes_to_xlsx(input_datasets_names, tmp_file_path, lambda name: dataiku.Dataset(name).get_dataframe())
+    dataframes_to_xlsx(input_datasets_names, tmp_file_path, lambda name: dataiku.Dataset(name))
 
     with open(tmp_file_path, 'rb', encoding=None) as f:
         output_folder.upload_stream(output_file_name, f)

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id" : "multisheet-excel-export",
-    "version" : "1.1.4",
+    "version" : "1.1.5",
 
 
     "meta" : {

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id" : "multisheet-excel-export",
-    "version" : "1.1.5",
+    "version" : "2.0.0",
 
 
     "meta" : {

--- a/python-lib/xlsx_writer.py
+++ b/python-lib/xlsx_writer.py
@@ -8,7 +8,6 @@ Conversion is based on Pandas feature conversion to xlsx.
 
 import logging
 import math
-import io
 from typing import Tuple
 from copy import copy
 
@@ -109,21 +108,31 @@ def auto_size_column_width(worksheet: Worksheet):
 
 
 
-
-def copy_sheet_to_workbook(source_sheet, target_workbook):
+# code inspired from https://openpyxl.readthedocs.io/en/stable/_modules/openpyxl/worksheet/copier.html
+def copy_sheet_to_workbook(source_sheet: Worksheet, target_workbook: Workbook) -> Worksheet:
+    """
+    Copy the source worksheet as a new worksheet in the target workbook
+    :param source_sheet: the source sheet
+    :param target_workbook: the workbook used to store the new sheet
+    :return: a reference to the created sheet inside the workbook
+    """
     logger.info(f"Copying sheet {source_sheet.title} to target workbook")
     target_sheet = target_workbook.create_sheet(source_sheet.title)
     for row in source_sheet:
         for cell in row:
             new_cell = target_sheet.cell(row=cell.row, column=cell.column, value=cell.value)
+            new_cell.data_type = cell.data_type
             if cell.has_style:
+                #new_cell._style = copy(cell._style)
                 new_cell.font = copy(cell.font)
                 new_cell.border = copy(cell.border)
                 new_cell.fill = copy(cell.fill)
+                new_cell.number_format = copy(cell.number_format)
+                new_cell.alignment = copy(cell.alignment)
 
     return target_sheet
 
-def dataframes_to_xlsx(input_dataset_names, xlsx_abs_path, worksheet_provider):
+def datasets_to_xlsx(input_dataset_names, xlsx_abs_path, worksheet_provider):
     """
     Write the input datasets into same excel into the folder
     :param input_dataset_names: the list of dataset to put in a single excel file, using one sheet (excel tab) per dataset

--- a/python-lib/xlsx_writer.py
+++ b/python-lib/xlsx_writer.py
@@ -123,7 +123,6 @@ def copy_sheet_to_workbook(source_sheet: Worksheet, target_workbook: Workbook) -
             new_cell = target_sheet.cell(row=cell.row, column=cell.column, value=cell.value)
             new_cell.data_type = cell.data_type
             if cell.has_style:
-                #new_cell._style = copy(cell._style)
                 new_cell.font = copy(cell.font)
                 new_cell.border = copy(cell.border)
                 new_cell.fill = copy(cell.fill)

--- a/python-lib/xlsx_writer.py
+++ b/python-lib/xlsx_writer.py
@@ -141,21 +141,21 @@ def rename_too_long_dataset_names(input_dataset_names: List[str]) -> Dict[str, s
     """
 
     return_map = {}
-    index_rename=-1
-    renaming_length = EXCEL_MAX_LEN_SHEET_NAME-2
+    index_rename = -1
+    renaming_length = EXCEL_MAX_LEN_SHEET_NAME - 2
     for name in input_dataset_names:
         if len(name) > EXCEL_MAX_LEN_SHEET_NAME:
-            index_rename+=1
-            rename= f"{name[0:renaming_length]}{index_rename:02d}"
+            index_rename += 1
+            rename = f"{name[0:renaming_length]}{index_rename:02d}"
             # Almost impossible case : a DS already has this name
             while rename in input_dataset_names:
-                index_rename+=1
-                rename= f"{name[0:renaming_length]}{index_rename:02d}"
+                index_rename += 1
+                rename = f"{name[0:renaming_length]}{index_rename:02d}"
 
             logger.info(f"Dataset {name} with a too long name will be stored as sheet {rename}")
-            return_map[name]=rename
+            return_map[name] = rename
         else:
-            return_map[name]=name
+            return_map[name] = name
 
     return return_map
 
@@ -168,7 +168,7 @@ def datasets_to_xlsx(input_dataset_names, xlsx_abs_path, worksheet_provider):
     :param dataset_provider: a lambda used to get the dataset
     """
 
-    logger.info(f"Building output excel file ... {xlsx_abs_path}")
+    logger.info(f"Building output excel file {xlsx_abs_path}")
     # The final workbook where all dataset sheets will be written
     workbook = Workbook()
     # remove the default sheet created
@@ -177,17 +177,18 @@ def datasets_to_xlsx(input_dataset_names, xlsx_abs_path, worksheet_provider):
     renaming_map = rename_too_long_dataset_names(input_dataset_names)
 
     for name in input_dataset_names:
-        ds_worksheet = worksheet_provider(name)
-        if ds_worksheet is None:
+        dataset_worksheet = worksheet_provider(name)
+        if dataset_worksheet is None:
             continue
 
         if name in renaming_map:
-            ds_worksheet.title = renaming_map[name]
+            dataset_worksheet.title = renaming_map[name]
         else:
             # should never happen
-            ds_worksheet.title = name
+            logger.warn(f"Failed to find a name for the workshhet {name}")
+            dataset_worksheet.title = name
         
-        target_sheet = copy_sheet_to_workbook(ds_worksheet, workbook)
+        target_sheet = copy_sheet_to_workbook(dataset_worksheet, workbook)
         
         logger.info(f"Styling excel sheet {target_sheet.title} in target workbook")
         style_header(target_sheet)

--- a/python-lib/xlsx_writer.py
+++ b/python-lib/xlsx_writer.py
@@ -27,35 +27,6 @@ EXCEL_MAX_LEN_SHEET_NAME = 31
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format='Multi-Sheet Excel Exporter | %(levelname)s - %(message)s')
 
-def style_header(worksheet: Worksheet, 
-                  font_name: str = "Calibri", 
-                  font_size: int = 11, 
-                  font_color : str = WHITE, 
-                  background_color : str = DATAIKU_TEAL,
-                  bold : bool = True
-                 ):
-    """
-    Style header of the worksheet
-    """
-
-    if worksheet.min_column < 1:
-        logger.warn(f"No header row for worksheet {worksheet}. Styling skipped.")
-        return
-
-    font = Font(name=font_name, size=font_size, color=font_color, bold=bold)
-    fill = PatternFill("solid", fgColor=background_color)
-
-    no_border_side = Side(border_style=None)
-    border = Border(left=no_border_side, right=no_border_side, top=no_border_side, bottom=no_border_side)
-
-    alignment = Alignment(vertical='bottom', horizontal='center')
-
-    for header_cell in worksheet[1]:
-        header_cell.font = font
-        header_cell.fill = fill
-        header_cell.border = border
-        header_cell.alignment = alignment
-
 def get_column_width(column: Tuple):
     """
     Find optimum column width based on content and header length
@@ -191,7 +162,6 @@ def datasets_to_xlsx(input_dataset_names, xlsx_abs_path, worksheet_provider):
         target_sheet = copy_sheet_to_workbook(dataset_worksheet, workbook)
         
         logger.info(f"Styling excel sheet {target_sheet.title} in target workbook")
-        style_header(target_sheet)
         auto_size_column_width(target_sheet)
 
         logger.info(f"Finished writing dataset {name} into excel sheet.")

--- a/tests/python/unit/test_multi_sheet_export.py
+++ b/tests/python/unit/test_multi_sheet_export.py
@@ -7,12 +7,12 @@ import tempfile
 
 
 def build_worksheet(headers, data):
-    wb = Workbook()
-    ws = wb.active
-    ws.append(headers)
+    workbook = Workbook()
+    worksheet = workbook.active
+    worksheet.append(headers)
     for row in data:
-        ws.append(row)
-    return ws
+        worksheet.append(row)
+    return worksheet
 
 
 def test_dataset_renames():

--- a/tests/python/unit/test_multi_sheet_export.py
+++ b/tests/python/unit/test_multi_sheet_export.py
@@ -1,28 +1,42 @@
 from xlsx_writer import dataframes_to_xlsx
 
 import os
+from openpyxl import Workbook
 import pandas as pd
 import tempfile
 
 
-def test_datasets_to_xlsx():
+def build_worksheet(headers, data):
+    wb = Workbook()
+    ws = wb.active
+    ws.append(headers)
+    for row in data:
+        ws.append(row)
+    return ws
 
+
+def test_datasets_to_xlsx():
     output_file_name = 'sample_test.xlsx'
     tmp_output_dir = tempfile.TemporaryDirectory(dir='.')
     output_file = os.path.join(tmp_output_dir.name, output_file_name)
 
-    df1 = pd.DataFrame({'dfId': [1], 'gender': ['M'], 'birthdate': ['1953/10/5']})
-    df2 = pd.DataFrame({'dfId': [2], 'gender': ['M']})
-    df3 = pd.DataFrame({'dfId': [3]})
+    df1 = build_worksheet(['dfId', 'gender', 'birthdate'], [[1, 'M', '1953/10/5'], [2, 'L', '1053/12/6']])
+    df2 = build_worksheet(['dfId', 'gender'], [[2, 'M']])
+    df3 = build_worksheet(['dfId'], [[3],[4],[5],[6],[7]])
     tables = {'df1': df1, 'df2': df2, 'df3': df3}
-
-    def dataframe_provider(name):
+    
+    def worksheet_provider(name):
         return tables[name]
 
-    dataframes_to_xlsx(['df1', 'df2', 'df3'], output_file, dataframe_provider)
+    dataframes_to_xlsx(['df1', 'df2', 'df3'], output_file, worksheet_provider)
 
-    df = pd.read_excel(output_file, sheet_name="df1")
+    df1_out = pd.read_excel(output_file, sheet_name="df1")
+    df2_out = pd.read_excel(output_file, sheet_name="df2")
+    df3_out = pd.read_excel(output_file, sheet_name="df3")
     os.remove(output_file)
 
-    assert len(tables["df1"]) == len(df)
+    # len on a panda dataframe returns number of rows without the column names
+    assert tables['df1'].max_row-1 == len(df1_out)
+    assert tables['df2'].max_row-1 == len(df2_out)
+    assert tables['df3'].max_row-1 == len(df3_out)
 

--- a/tests/python/unit/test_multi_sheet_export.py
+++ b/tests/python/unit/test_multi_sheet_export.py
@@ -33,8 +33,8 @@ def test_dataset_renames():
         "very_very_long_name_with_too_much_character13",
         "very_very_long_name_with_too_much_character14",
         "very_very_long_name_with_too_much_character15",
-        "very_very_long_name_with_too_09", # To test that too long DS doesn't get renamed to a dataset with correct leng
-        "very_very_long_name_with_too_14", # To test that too long DS doesn't get renamed to a dataset with correct leng
+        "very_very_long_name_with_too_09", # To test that too long DS doesn't get renamed to a dataset with correct len
+        "very_very_long_name_with_too_14", # To test that too long DS doesn't get renamed to a dataset with correct len
         "finally_normal_dataset",
         "finally_normal_dataset2"
 

--- a/tests/python/unit/test_multi_sheet_export.py
+++ b/tests/python/unit/test_multi_sheet_export.py
@@ -1,4 +1,4 @@
-from xlsx_writer import datasets_to_xlsx
+from xlsx_writer import datasets_to_xlsx, rename_too_long_dataset_names
 
 import os
 from openpyxl import Workbook
@@ -13,6 +13,56 @@ def build_worksheet(headers, data):
     for row in data:
         ws.append(row)
     return ws
+
+
+def test_dataset_renames():
+    original_list = [
+        "very_very_long_name_with_too_much_character0",
+        "very_very_long_name_with_too_much_character1",
+        "very_very_long_name_with_too_much_character2",
+        "very_very_long_name_with_too_much_character3",
+        "very_very_long_name_with_too_much_character4",
+        "very_very_long_name_with_too_much_character5",
+        "very_very_long_name_with_too_much_character6",
+        "very_very_long_name_with_too_much_character7",
+        "very_very_long_name_with_too_much_character8",
+        "very_very_long_name_with_too_much_character9",
+        "very_very_long_name_with_too_much_character10",
+        "very_very_long_name_with_too_much_character11",
+        "very_very_long_name_with_too_much_character12",
+        "very_very_long_name_with_too_much_character13",
+        "very_very_long_name_with_too_much_character14",
+        "very_very_long_name_with_too_much_character15",
+        "very_very_long_name_with_too_09", # To test that too long DS doesn't get renamed to a dataset with correct leng
+        "very_very_long_name_with_too_14", # To test that too long DS doesn't get renamed to a dataset with correct leng
+        "finally_normal_dataset",
+        "finally_normal_dataset2"
+
+    ]
+    test_rename_map = rename_too_long_dataset_names(original_list)
+    assert test_rename_map["finally_normal_dataset"] == "finally_normal_dataset"
+    assert test_rename_map["finally_normal_dataset2"] == "finally_normal_dataset2"
+    assert test_rename_map["very_very_long_name_with_too_14"] == "very_very_long_name_with_too_14"
+    assert test_rename_map["very_very_long_name_with_too_09"] == "very_very_long_name_with_too_09"
+
+    assert test_rename_map["very_very_long_name_with_too_much_character0"]  == "very_very_long_name_with_too_00"
+    assert test_rename_map["very_very_long_name_with_too_much_character1"]  == "very_very_long_name_with_too_01"
+    assert test_rename_map["very_very_long_name_with_too_much_character2"]  == "very_very_long_name_with_too_02"
+    assert test_rename_map["very_very_long_name_with_too_much_character3"]  == "very_very_long_name_with_too_03"
+    assert test_rename_map["very_very_long_name_with_too_much_character4"]  == "very_very_long_name_with_too_04"
+    assert test_rename_map["very_very_long_name_with_too_much_character5"]  == "very_very_long_name_with_too_05"
+    assert test_rename_map["very_very_long_name_with_too_much_character6"]  == "very_very_long_name_with_too_06"
+    assert test_rename_map["very_very_long_name_with_too_much_character7"]  == "very_very_long_name_with_too_07"
+    assert test_rename_map["very_very_long_name_with_too_much_character8"]  == "very_very_long_name_with_too_08"
+    assert test_rename_map["very_very_long_name_with_too_much_character9"]  == "very_very_long_name_with_too_10"
+    assert test_rename_map["very_very_long_name_with_too_much_character10"] == "very_very_long_name_with_too_11"
+    assert test_rename_map["very_very_long_name_with_too_much_character11"] == "very_very_long_name_with_too_12"
+    assert test_rename_map["very_very_long_name_with_too_much_character12"] == "very_very_long_name_with_too_13"
+    assert test_rename_map["very_very_long_name_with_too_much_character13"] == "very_very_long_name_with_too_15"
+    assert test_rename_map["very_very_long_name_with_too_much_character14"] == "very_very_long_name_with_too_16"
+    assert test_rename_map["very_very_long_name_with_too_much_character15"] == "very_very_long_name_with_too_17"
+
+
 
 
 def test_datasets_to_xlsx():

--- a/tests/python/unit/test_multi_sheet_export.py
+++ b/tests/python/unit/test_multi_sheet_export.py
@@ -1,4 +1,4 @@
-from xlsx_writer import dataframes_to_xlsx
+from xlsx_writer import datasets_to_xlsx
 
 import os
 from openpyxl import Workbook
@@ -28,7 +28,7 @@ def test_datasets_to_xlsx():
     def worksheet_provider(name):
         return tables[name]
 
-    dataframes_to_xlsx(['df1', 'df2', 'df3'], output_file, worksheet_provider)
+    datasets_to_xlsx(['df1', 'df2', 'df3'], output_file, worksheet_provider)
 
     df1_out = pd.read_excel(output_file, sheet_name="df1")
     df2_out = pd.read_excel(output_file, sheet_name="df2")


### PR DESCRIPTION
Hello,

card [sc-184818](https://app.shortcut.com/dataiku/story/184418/multisheet-exporter-add-a-way-to-apply-conditional-formatting)


We want to colorize cells in exported excel file with the same color show in the dataset explore view. Note that we export only the COLORS and not the rules.

The code leverage what was done in this PR : 
https://github.com/dataiku/dip/pull/27672

I also had a look of what has been done for the export to html which keeps the color formatting : 
https://github.com/dataiku/dip/pull/28655

Reminder : an excel file is also called a `workbook`, and a `workbook` can have several tabs, a tab is actually called a `worksheet`

For this PR I considered lot of options that all had their drawback
- Return coloring in get_dataframe() ==> Too risky/sensible as central public API method
- Return coloring in iter_tuples() ==> Too risky as well
- Return coloring rules in get_config/get_settings ==> I did it but it is useless because we want the colors, not the rules
- Parse a colored html to get back the colors, and fill the excel file with it ==> Way too overkill
- Create a new formatter in the BE ==> Too much work for this card

So my choice was to reuse `mydataset.raw_formatted_data(format="excel", format_params={ "applyColoring": True })` 
Small difficulty : parsing the excel output file with `panda.read_excel()` doesn't work.  So I had to directly use `openpyxl` library. Good news is that for the plugin, we didn't really need to go via `panda`. Everything is iso

Note also that `openpyxl`  doesn't allow to copy worksheet between workbooks, that is why I had to do it manually.

Adapting this code for the [Excel Templater](https://github.com/dataiku/dss-plugin-excel-templater) plugin looks feasible. Card will be [sc-190645](https://app.shortcut.com/dataiku/story/190645/excel-templater-add-a-way-to-apply-conditional-formatting)

Subject open to discussion when you read the code : I've added this part in the code to be robust to future evolution of the export to excel method, if some day the sheet name changes, the code will just use the only sheet created in the excel file

```python
elif len(wb.sheetnames) == 1:
    logger.warn(f"Default DSS default sheet name has changed from {DEFAULT_DATAIKU_SHEET_NAME} to {wb.sheetnames[0]}")
    return wb[wb.sheetnames[0]]
```

I've added the checkbox asked by this card : [sc-182181](https://app.shortcut.com/dataiku/story/182181/multisheet-excel-export-add-checkbox-to-apply-conditional-formatting)

After a quick validation, this ticket comes also free with this PR : [sc-180664](https://app.shortcut.com/dataiku/story/180664/multisheet-excel-export-plugin-preserve-dataset-column-type-when-writing-to-excel)


