### PR TITLE
[sc-198001] Fix out of memory while exporting large datasets + cache optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Version 2.1.0](https://github.com/dataiku/dss-plugin-multisheet-excel-export/releases/tag/v2.1.0) - Major release - 2024-09
 - Bug fix: one temporary workbook is used per dataset to avoid out of memory issues while exporting large datasets. All these temporary workbooks are merged at the end to generate the final excel file
-- Optimization: using of a cache for styles to avoid useless copies decreasing the execution time about 30-40%
+- Optimizations: using of a cache for styles to avoid useless copies + openpyxl write only mode with lxml
 
 ## [Version 2.0.0](https://github.com/dataiku/dss-plugin-multisheet-excel-export/releases/tag/v2.0.0) - Major release - 2024-07
 - Important : Column type changed ! From this version, cell types in excel will reflect the storage type in DSS. For example, string column containing only numbers will be exported as text column. If you want a number column in excel, you need to have a integer/float column on DSS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 2.1.0](https://github.com/dataiku/dss-plugin-multisheet-excel-export/releases/tag/v2.1.0) - Major release - 2024-09
+- Bug fix: one temporary workbook is used per dataset to avoid out of memory issues while exporting large datasets. All these temporary workbooks are merged at the end to generate the final excel file
+- Optimization: using of a cache for styles to avoid useless copies decreasing the execution time about 30-40%
+
 ## [Version 2.0.0](https://github.com/dataiku/dss-plugin-multisheet-excel-export/releases/tag/v2.0.0) - Major release - 2024-07
 - Important : Column type changed ! From this version, cell types in excel will reflect the storage type in DSS. For example, string column containing only numbers will be exported as text column. If you want a number column in excel, you need to have a integer/float column on DSS
 - Export dataset conditional formatting colors (colors the cells, does not export rules)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This plugin relies on the [openpyxl](https://openpyxl.readthedocs.io/en/stable/)
 
 Once the plugin is successfully installed, select the datasets that you want to export as one excel file. 
 Then run the Multi-Sheet Excel Export recipe from the flow. 
-It will create a folder in your flow containing the output `.xls` file. Each sheet of this file contains one dataset and is named after this dataset.
+It will create a folder in your flow containing the output `.xlsx` file. Each sheet of this file contains one dataset and is named after this dataset.
  
 ## Running tests
 

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,2 +1,3 @@
 openpyxl==3.0.6
 pathvalidate==2.3.0
+lxml==5.3.0

--- a/custom-recipes/to-excel/recipe.py
+++ b/custom-recipes/to-excel/recipe.py
@@ -42,10 +42,10 @@ def get_excel_worksheet(dataset: dataiku.Dataset, apply_conditional_formatting: 
         if DEFAULT_DATAIKU_SHEET_NAME in workbook:
             return workbook[DEFAULT_DATAIKU_SHEET_NAME]
         elif len(workbook.sheetnames) == 1:
-            logger.warn(f"Default DSS default sheet name has changed from '{DEFAULT_DATAIKU_SHEET_NAME}' to '{workbook.sheetnames[0]}'")
+            logger.warning(f"Default DSS default sheet name has changed from '{DEFAULT_DATAIKU_SHEET_NAME}' to '{workbook.sheetnames[0]}'")
             return workbook[workbook.sheetnames[0]]
 
-    logger.error("Error getting Excel workbook from DSS dataset '{dataset.short_name}', this dataset will not be exported")
+    logger.error(f"Error getting Excel workbook from DSS dataset '{dataset.short_name}', this dataset will not be exported")
     return None
 
 

--- a/custom-recipes/to-excel/recipe.py
+++ b/custom-recipes/to-excel/recipe.py
@@ -18,13 +18,14 @@ from xlsx_writer import datasets_to_xlsx
 from typing import Union
 
 DEFAULT_DATAIKU_SHEET_NAME = "Sheet1"
-READ_CHUNK_SIZE = 1024 * 1024 # 1Mbytes
+READ_CHUNK_SIZE = 1024 * 1024  # 1Mbytes
+
 
 def get_excel_worksheet(dataset: dataiku.Dataset, apply_conditional_formatting: bool) -> Union[Workbook, None]:
     logger.info(f"Getting Excel workbook from DSS dataset '{dataset.short_name}'...")
     workbook = None
     with tempfile.NamedTemporaryFile(delete=True) as tmp_file:
-        with dataset.raw_formatted_data(format="excel", format_params={ "applyColoring": apply_conditional_formatting }) as stream:
+        with dataset.raw_formatted_data(format="excel", format_params={"applyColoring": apply_conditional_formatting}) as stream:
             # read steam with chunks to save RAM
             chunk_size = READ_CHUNK_SIZE
             while True:
@@ -32,8 +33,8 @@ def get_excel_worksheet(dataset: dataiku.Dataset, apply_conditional_formatting: 
                 if not chunk:
                     break
                 tmp_file.write(chunk)
-        tmp_file.flush() # Make sure file is written on disk
-        tmp_file.seek(0) # Read back from start of file to load it in the workbook
+        tmp_file.flush()  # Make sure file is written on disk
+        tmp_file.seek(0)  # Read back from start of file to load it in the workbook
 
         # DEV WARNING : Excel exported file contains header row in Calibri and rest in Aptos Narrow font. But load_workbook converts everything into Calibri
         workbook = load_workbook(tmp_file)

--- a/custom-recipes/to-excel/recipe.py
+++ b/custom-recipes/to-excel/recipe.py
@@ -21,7 +21,7 @@ DEFAULT_DATAIKU_SHEET_NAME = "Sheet1"
 READ_CHUNK_SIZE = 1024 * 1024 # 1Mbytes
 
 def get_excel_worksheet(dataset: dataiku.Dataset, apply_conditional_formatting: bool) -> Union[Workbook, None]:
-    logger.info(f"Getting Excel workbook from DSS dataset {dataset.short_name}")
+    logger.info(f"Getting Excel workbook from DSS dataset '{dataset.short_name}'...")
     workbook = None
     with tempfile.NamedTemporaryFile(delete=True) as tmp_file:
         with dataset.raw_formatted_data(format="excel", format_params={ "applyColoring": apply_conditional_formatting }) as stream:
@@ -42,10 +42,10 @@ def get_excel_worksheet(dataset: dataiku.Dataset, apply_conditional_formatting: 
         if DEFAULT_DATAIKU_SHEET_NAME in workbook:
             return workbook[DEFAULT_DATAIKU_SHEET_NAME]
         elif len(workbook.sheetnames) == 1:
-            logger.warn(f"Default DSS default sheet name has changed from {DEFAULT_DATAIKU_SHEET_NAME} to {workbook.sheetnames[0]}")
+            logger.warn(f"Default DSS default sheet name has changed from '{DEFAULT_DATAIKU_SHEET_NAME}' to '{workbook.sheetnames[0]}'")
             return workbook[workbook.sheetnames[0]]
 
-    logger.error("Error getting Excel workbook from DSS dataset {dataset.short_name}, this dataset will not be exported")
+    logger.error("Error getting Excel workbook from DSS dataset '{dataset.short_name}', this dataset will not be exported")
     return None
 
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id" : "multisheet-excel-export",
-    "version" : "2.0.0",
+    "version" : "2.1.0",
 
 
     "meta" : {

--- a/python-lib/xlsx_writer.py
+++ b/python-lib/xlsx_writer.py
@@ -96,7 +96,13 @@ class StyleCached:
         self.alignment = copy(alignment)
 
     def __eq__(self, cell: Cell):
-       return cell.fill.__eq__(self.fill) and cell.alignment.__eq__(self.alignment) and cell.number_format.__eq__(self.number_format) and cell.border.__eq__(self.border) and cell.font.__eq__(self.font)
+       return (cell.fill.__eq__(self.fill)
+               and cell.font.__eq__(self.font)
+               and cell.alignment.__eq__(self.alignment)
+               and cell.number_format.__eq__(self.number_format)
+               # 1 border all the time so not needed to check the line below
+               # and cell.border.__eq__(self.border) 
+        )
 
 style_cache = []
 def get_style_cached(cell: Cell):
@@ -215,7 +221,6 @@ def datasets_to_xlsx(input_dataset_names, xlsx_abs_path, worksheet_provider):
 
         workbook_tmp_files.append(tempfile.NamedTemporaryFile())
         temp_workbook.save(workbook_tmp_files[-1].name)
-
         # Free memory
         del temp_sheet
         temp_workbook.close()
@@ -259,5 +264,30 @@ def datasets_to_xlsx(input_dataset_names, xlsx_abs_path, worksheet_provider):
                 archive.write(os.path.join(root, file), 
                         os.path.relpath(os.path.join(root, file), 
                                         os.path.join(template_workbook_extract_dir.name, '.')))
+                
+    print_cache()
 
     logger.info("Done writing output xlsx file.")
+
+def print_cache():
+    fonts = []
+    borders = []
+    fills = []
+    number_formats = []
+    alignments = []
+
+    def add_style_if_not_exist(style, list):
+        if list:
+            for s in list:
+                if s.__eq__(style):
+                    return
+        list.append(style)
+
+    for cache in style_cache:
+        add_style_if_not_exist(cache.font, fonts)
+        add_style_if_not_exist(cache.border, borders)
+        add_style_if_not_exist(cache.fill, fills)
+        add_style_if_not_exist(cache.alignment, alignments)
+        add_style_if_not_exist(cache.number_format, number_formats)
+
+    logger.info(f"Style counts (fonts: {len(fonts)}; borders: {len(borders)}; fills: {len(fills)}; alignments: {len(alignments)}; number_formats: {len(number_formats)})")

--- a/tests/python/unit/test_multi_sheet_export.py
+++ b/tests/python/unit/test_multi_sheet_export.py
@@ -33,8 +33,8 @@ def test_dataset_renames():
         "very_very_long_name_with_too_much_character13",
         "very_very_long_name_with_too_much_character14",
         "very_very_long_name_with_too_much_character15",
-        "very_very_long_name_with_too_09", # To test that too long DS doesn't get renamed to a dataset with correct len
-        "very_very_long_name_with_too_14", # To test that too long DS doesn't get renamed to a dataset with correct len
+        "very_very_long_name_with_too_09",  # To test that too long DS doesn't get renamed to a dataset with correct len
+        "very_very_long_name_with_too_14",  # To test that too long DS doesn't get renamed to a dataset with correct len
         "finally_normal_dataset",
         "finally_normal_dataset2"
 
@@ -45,24 +45,22 @@ def test_dataset_renames():
     assert test_rename_map["very_very_long_name_with_too_14"] == "very_very_long_name_with_too_14"
     assert test_rename_map["very_very_long_name_with_too_09"] == "very_very_long_name_with_too_09"
 
-    assert test_rename_map["very_very_long_name_with_too_much_character0"]  == "very_very_long_name_with_too_00"
-    assert test_rename_map["very_very_long_name_with_too_much_character1"]  == "very_very_long_name_with_too_01"
-    assert test_rename_map["very_very_long_name_with_too_much_character2"]  == "very_very_long_name_with_too_02"
-    assert test_rename_map["very_very_long_name_with_too_much_character3"]  == "very_very_long_name_with_too_03"
-    assert test_rename_map["very_very_long_name_with_too_much_character4"]  == "very_very_long_name_with_too_04"
-    assert test_rename_map["very_very_long_name_with_too_much_character5"]  == "very_very_long_name_with_too_05"
-    assert test_rename_map["very_very_long_name_with_too_much_character6"]  == "very_very_long_name_with_too_06"
-    assert test_rename_map["very_very_long_name_with_too_much_character7"]  == "very_very_long_name_with_too_07"
-    assert test_rename_map["very_very_long_name_with_too_much_character8"]  == "very_very_long_name_with_too_08"
-    assert test_rename_map["very_very_long_name_with_too_much_character9"]  == "very_very_long_name_with_too_10"
+    assert test_rename_map["very_very_long_name_with_too_much_character0"] == "very_very_long_name_with_too_00"
+    assert test_rename_map["very_very_long_name_with_too_much_character1"] == "very_very_long_name_with_too_01"
+    assert test_rename_map["very_very_long_name_with_too_much_character2"] == "very_very_long_name_with_too_02"
+    assert test_rename_map["very_very_long_name_with_too_much_character3"] == "very_very_long_name_with_too_03"
+    assert test_rename_map["very_very_long_name_with_too_much_character4"] == "very_very_long_name_with_too_04"
+    assert test_rename_map["very_very_long_name_with_too_much_character5"] == "very_very_long_name_with_too_05"
+    assert test_rename_map["very_very_long_name_with_too_much_character6"] == "very_very_long_name_with_too_06"
+    assert test_rename_map["very_very_long_name_with_too_much_character7"] == "very_very_long_name_with_too_07"
+    assert test_rename_map["very_very_long_name_with_too_much_character8"] == "very_very_long_name_with_too_08"
+    assert test_rename_map["very_very_long_name_with_too_much_character9"] == "very_very_long_name_with_too_10"
     assert test_rename_map["very_very_long_name_with_too_much_character10"] == "very_very_long_name_with_too_11"
     assert test_rename_map["very_very_long_name_with_too_much_character11"] == "very_very_long_name_with_too_12"
     assert test_rename_map["very_very_long_name_with_too_much_character12"] == "very_very_long_name_with_too_13"
     assert test_rename_map["very_very_long_name_with_too_much_character13"] == "very_very_long_name_with_too_15"
     assert test_rename_map["very_very_long_name_with_too_much_character14"] == "very_very_long_name_with_too_16"
     assert test_rename_map["very_very_long_name_with_too_much_character15"] == "very_very_long_name_with_too_17"
-
-
 
 
 def test_datasets_to_xlsx():
@@ -72,9 +70,9 @@ def test_datasets_to_xlsx():
 
     df1 = build_worksheet(['dfId', 'gender', 'birthdate'], [[1, 'M', '1953/10/5'], [2, 'L', '1053/12/6']])
     df2 = build_worksheet(['dfId', 'gender'], [[2, 'M']])
-    df3 = build_worksheet(['dfId'], [[3],[4],[5],[6],[7]])
+    df3 = build_worksheet(['dfId'], [[3], [4], [5], [6], [7]])
     tables = {'df1': df1, 'df2': df2, 'df3': df3}
-    
+
     def worksheet_provider(name):
         return tables[name]
 
@@ -89,4 +87,3 @@ def test_datasets_to_xlsx():
     assert tables['df1'].max_row-1 == len(df1_out)
     assert tables['df2'].max_row-1 == len(df2_out)
     assert tables['df3'].max_row-1 == len(df3_out)
-


### PR DESCRIPTION
One temporary workbook is used per dataset to avoid out of memory issues while exporting large datasets. All these temporary workbooks are merged at the end to generate the final excel file.
See attached memory profiler logs to see the fix:
[multi_sheet_export_fix_version_mem_profle.log](https://github.com/user-attachments/files/16908515/multi_sheet_export_fix_version_mem_profle.log)
[multi_sheet_export_old_version_mem_profle.log](https://github.com/user-attachments/files/16908517/multi_sheet_export_old_version_mem_profle.log)

using of a cache for styles to avoid useless copies decreasing the execution time about 30-40%:
See attached plugin logs to see the improvement:
[multi_sheet_export_fix_version.log](https://github.com/user-attachments/files/16908532/multi_sheet_export_fix_version.log)
[multi_sheet_export_old_version.log](https://github.com/user-attachments/files/16908534/multi_sheet_export_old_version.log)
