### PR TITLE
[sc-323687] Feat: Add Cobuild support metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Version 2.3.0](https://github.com/dataiku/dss-plugin-multisheet-excel-export/releases/tag/v2.3.0) - Feature release - 2026-08
+- Add Cobuild support to the ontology tagging recipe
+
 ## [Version 2.2.1](https://github.com/dataiku/dss-plugin-multisheet-excel-export/releases/tag/v2.2.1) - Minor release - 2026-01
 - Updated plugin to python 3.12 and 3.13
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile variables set automatically
-plugin_id=`cat plugin.json | python -c "import sys, json; print(str(json.load(sys.stdin)['id']).replace('/',''))"`
-plugin_version=`cat plugin.json | python -c "import sys, json; print(str(json.load(sys.stdin)['version']).replace('/',''))"`
+plugin_id=`cat plugin.json | python3 -c "import sys, json; print(str(json.load(sys.stdin)['id']).replace('/',''))"`
+plugin_version=`cat plugin.json | python3 -c "import sys, json; print(str(json.load(sys.stdin)['version']).replace('/',''))"`
 archive_file_name="dss-plugin-${plugin_id}-${plugin_version}.zip"
 remote_url=`git config --get remote.origin.url`
 last_commit_id=`git rev-parse HEAD`

--- a/custom-recipes/to-excel/Cobuild.md
+++ b/custom-recipes/to-excel/Cobuild.md
@@ -1,7 +1,5 @@
 # Cobuild guidance
 
-Workbook behavior:
-- Use an existing managed folder for `main_output`. If none exists, ask the user to create one and provide it; do not invent or guess a folder reference.
-- The recipe creates one worksheet per `input_dataset` and uses dataset names as worksheet names unless a custom mapping overrides them.
-- Set `output_workbook_name` without an extension; the recipe appends `.xlsx` when writing the workbook.
-- When `renaming_sheets=true`, each `dataset_to_sheet_mapping` entry has the shape `{"dataset_name":"<input dataset>","sheet_name":"<worksheet name>"}`. Each `dataset_name` must identify one of the selected inputs; inputs without a mapping keep their default worksheet names.
+- Use an existing managed folder for `folder`. If the user did not specify one, ask them to provide one or create it in DSS; do not invent a folder reference.
+- The recipe creates one worksheet per `input_dataset`, in input order, and uses dataset names as worksheet names unless a custom mapping overrides them.
+- When `renaming_sheets=true`, each `dataset_to_sheet_mapping` entry has the shape `{"dataset_name":"<input dataset>","sheet_name":"<worksheet name>"}`. Each dataset must be a selected input, each sheet name must be at most 31 characters, and unmapped inputs keep their default worksheet names.

--- a/custom-recipes/to-excel/Cobuild.md
+++ b/custom-recipes/to-excel/Cobuild.md
@@ -1,5 +1,3 @@
-# Cobuild guidance
-
 - Use an existing managed folder for `folder`. If the user did not specify one, ask them to provide one or create it in DSS; do not invent a folder reference.
 - The recipe creates one worksheet per `input_dataset`, in input order, and uses dataset names as worksheet names unless a custom mapping overrides them.
 - When `renaming_sheets=true`, each `dataset_to_sheet_mapping` entry has the shape `{"dataset_name":"<input dataset>","sheet_name":"<worksheet name>"}`. Each dataset must be a selected input, each sheet name must be at most 31 characters, and unmapped inputs keep their default worksheet names.

--- a/custom-recipes/to-excel/Cobuild.md
+++ b/custom-recipes/to-excel/Cobuild.md
@@ -1,6 +1,7 @@
 # Cobuild guidance
 
 Workbook behavior:
+- Use an existing managed folder for `main_output`. If none exists, ask the user to create one and provide it; do not invent or guess a folder reference.
 - The recipe creates one worksheet per `input_dataset` and uses dataset names as worksheet names unless a custom mapping overrides them.
 - Set `output_workbook_name` without an extension; the recipe appends `.xlsx` when writing the workbook.
 - When `renaming_sheets=true`, each `dataset_to_sheet_mapping` entry has the shape `{"dataset_name":"<input dataset>","sheet_name":"<worksheet name>"}`. Each `dataset_name` must identify one of the selected inputs; inputs without a mapping keep their default worksheet names.

--- a/custom-recipes/to-excel/Cobuild.md
+++ b/custom-recipes/to-excel/Cobuild.md
@@ -1,0 +1,16 @@
+# Cobuild guidance
+
+Use this recipe to export multiple input datasets into one Excel workbook, with one worksheet per dataset.
+
+Roles:
+- `input_dataset`: required input datasets to export. This role accepts multiple datasets.
+- `folder`: required output managed folder where the workbook is written.
+
+Core configuration:
+- Set `output_workbook_name` to the workbook name without the `.xlsx` extension.
+- Set `export_conditional_formatting=true` only when conditional formatting should be preserved in the exported sheets.
+- Keep `renaming_sheets=false` to use dataset names as worksheet names.
+- If custom worksheet names are needed, set `renaming_sheets=true` and provide `dataset_to_sheet_mapping` entries. Each entry contains `dataset_name` and `sheet_name`; `dataset_name` must be one of the selected input datasets.
+
+Output behavior:
+- The recipe writes `output_workbook_name + ".xlsx"` to the output managed folder.

--- a/custom-recipes/to-excel/Cobuild.md
+++ b/custom-recipes/to-excel/Cobuild.md
@@ -1,16 +1,6 @@
 # Cobuild guidance
 
-Use this recipe to export multiple input datasets into one Excel workbook, with one worksheet per dataset.
-
-Roles:
-- `input_dataset`: required input datasets to export. This role accepts multiple datasets.
-- `folder`: required output managed folder where the workbook is written.
-
-Core configuration:
-- Set `output_workbook_name` to the workbook name without the `.xlsx` extension.
-- Set `export_conditional_formatting=true` only when conditional formatting should be preserved in the exported sheets.
-- Keep `renaming_sheets=false` to use dataset names as worksheet names.
-- If custom worksheet names are needed, set `renaming_sheets=true` and provide `dataset_to_sheet_mapping` entries. Each entry contains `dataset_name` and `sheet_name`; `dataset_name` must be one of the selected input datasets.
-
-Output behavior:
-- The recipe writes `output_workbook_name + ".xlsx"` to the output managed folder.
+Workbook behavior:
+- The recipe creates one worksheet per `input_dataset` and uses dataset names as worksheet names unless a custom mapping overrides them.
+- Set `output_workbook_name` without an extension; the recipe appends `.xlsx` when writing the workbook.
+- When `renaming_sheets=true`, each `dataset_to_sheet_mapping` entry has the shape `{"dataset_name":"<input dataset>","sheet_name":"<worksheet name>"}`. Each `dataset_name` must identify one of the selected inputs; inputs without a mapping keep their default worksheet names.

--- a/custom-recipes/to-excel/recipe.json
+++ b/custom-recipes/to-excel/recipe.json
@@ -37,6 +37,7 @@
         {
             "name": "output_workbook_name",
             "label": "Name of the Excel Workbook",
+            "description": "Name of the output file without an extension. The recipe appends .xlsx automatically.",
             "type": "STRING",
             "defaultValue": "output",
             "mandatory": true

--- a/custom-recipes/to-excel/recipe.json
+++ b/custom-recipes/to-excel/recipe.json
@@ -6,6 +6,9 @@
     },
 
     "kind" : "PYTHON",
+    "cobuild": {
+        "supported": true
+    },
     "selectableFromDataset": "input_dataset",
 
     "inputRoles" : [

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id" : "multisheet-excel-export",
-    "version" : "2.2.1",
+    "version" : "2.3.0",
 
 
     "meta" : {


### PR DESCRIPTION
## Overview

Card: [sc-323687](https://app.shortcut.com/dataiku/story/323687/add-support-for-plugin-recipes-datasets-in-cobuild)

- Marks the `to-excel` recipe as Cobuild-supported.
- Guides Cobuild to use the required `folder` output role with an existing managed folder. When the user has not specified one, Cobuild asks them to provide or create it instead of inventing a folder reference.
- Documents worksheet creation order, default dataset-based names, and custom mapping requirements, including Excel's 31-character sheet-name limit.
- Updates the `output_workbook_name` parameter description in `recipe.json` to clarify that the value excludes the extension and that the recipe appends `.xlsx` automatically.
- Bump version to `2.3.0`

Cobuild plugin-recipe support is implemented by [dataiku/dip#49952](https://github.com/dataiku/dip/pull/49952).
